### PR TITLE
complete instructions for oxygen levels exercise

### DIFF
--- a/2-mandatory/2-oxygen-levels.js
+++ b/2-mandatory/2-oxygen-levels.js
@@ -6,7 +6,12 @@
 
     To be safe, they need to land on the first unnamed planet that has Oxygen levels between 19.5% and 23.5%.
 
+    Sometimes the computer reports values that are not percentages (ending with "%"). The Space Voyagers
+    cannot trust these values, so they have to ignore anything that is not a percentage.
+
     Write a function that finds the oxygen level of the first safe planet - Oxygen between 19.5% and 23.5%
+
+    If no safe planet can be found, the function must return `undefined`.
 
     Some string methods that might help you here are .replace() and .substring().
 */


### PR DESCRIPTION
The instructions for this exercise were not quite complete - some requirements were encoded into unit tests that were not mentioned in the original instructions.

I'm not sure whether they were intentionally incomplete, and that trainees are expected to look at failing tests to find hidden requirements for the exercise. This PR is making the assumption that actually we do want to include full requirements in the docblock before the function.
